### PR TITLE
Support an include option in .clang_complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ the conceal feature.
 ```
 
 - Compiler options can be configured in a `.clang_complete` file in each project
-  root.  Example of `.clang_complete` file:
+  root.  `.clang_complete` can also include other files in the same format to
+  share options between projects.  Example of `.clang_complete` file:
 
 ```
 -DDEBUG
@@ -38,6 +39,7 @@ the conceal feature.
 -I../common
 -I/usr/include/c++/4.5.3/
 -I/usr/include/c++/4.5.3/x86_64-slackware-linux/
+@../../.clang_complete
 ```
 
 ## Usage

--- a/doc/clang_complete.txt
+++ b/doc/clang_complete.txt
@@ -79,12 +79,20 @@ of linker arguments in .clang_complete file. They will lead to completion
 failure when using clang executable and will be completely ignored by
 libclang.
 
+A .clang_complete file can include other files with compiler options. This is
+useful if multiple projects share the same set of common options. An include
+option consists of an '@' sign followed by an absolute or relative path to
+another options file. This option can appear multiple times. It is also
+handled recursively so any depth of nesting is supported.
+
 Example .clang_complete file: >
  -DDEBUG
  -include ../config.h
  -I../common
  -I/usr/include/c++/4.5.3/
  -I/usr/include/c++/4.5.3/x86_64-slackware-linux/
+ @../../.clang_complete
+ @/home/user/universal_options
 <
 ==============================================================================
 5. Options					*clang_complete-options*


### PR DESCRIPTION
Add support for an include option '@filename' in .clang_complete files
to recursively include other files with common options.